### PR TITLE
fix: add react-dom types

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "license": "ISC",
   "dependencies": {
     "@mjackson/node-fetch-server": "^0.3.0",
-    "@types/react": "^18.3.12",
     "esbuild": "^0.24.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "react-router": "7.0.0-pre.6"
   },
   "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
     "@types/node": "^22.4.1",
     "concurrently": "^9.1.0",
     "prettier": "^3.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@types/node':
         specifier: ^22.4.1
         version: 22.9.1
+      '@types/react-dom':
+        specifier: ^18.3.1
+        version: 18.3.1
       concurrently:
         specifier: ^9.1.0
         version: 9.1.0
@@ -214,6 +217,9 @@ packages:
 
   '@types/prop-types@15.7.13':
     resolution: {integrity: sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==}
+
+  '@types/react-dom@18.3.1':
+    resolution: {integrity: sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==}
 
   '@types/react@18.3.12':
     resolution: {integrity: sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==}
@@ -624,6 +630,10 @@ snapshots:
       undici-types: 6.19.8
 
   '@types/prop-types@15.7.13': {}
+
+  '@types/react-dom@18.3.1':
+    dependencies:
+      '@types/react': 18.3.12
 
   '@types/react@18.3.12':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@mjackson/node-fetch-server':
         specifier: ^0.3.0
         version: 0.3.0
-      '@types/react':
-        specifier: ^18.3.12
-        version: 18.3.12
       esbuild:
         specifier: ^0.24.0
         version: 0.24.0
@@ -30,6 +27,9 @@ importers:
       '@types/node':
         specifier: ^22.4.1
         version: 22.9.1
+      '@types/react':
+        specifier: ^18.3.12
+        version: 18.3.12
       '@types/react-dom':
         specifier: ^18.3.1
         version: 18.3.1


### PR DESCRIPTION
Running `pnpm dev` gave me an error

```
entry.client.tsx(2,29): error TS7016: Could not find a declaration file for module 'react-dom/client'
```